### PR TITLE
Initialize backend with FastAPI stubs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+RUN pip install --no-cache-dir fastapi uvicorn[standard] sqlmodel
+
+COPY app /app
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,0 +1,3 @@
+"""Database access layer with CRUD helper functions."""
+
+# Functions interacting with models will be added here in the future.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+# Allow all origins during development. Adjust in production.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,21 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class Source(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+
+class Item(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    content: str
+    source_id: Optional[int] = Field(default=None, foreign_key="source.id")
+
+
+class Feedback(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    item_id: int = Field(foreign_key="item.id")
+    rating: int
+    comment: Optional[str] = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,3 @@
+"""Pydantic models used for request and response bodies."""
+
+# Future schema definitions will go here.


### PR DESCRIPTION
## Summary
- scaffold backend FastAPI app under `backend/app`
- provide placeholder SQLModel classes
- add stubs for schemas and CRUD helpers
- include a Dockerfile for running the backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a9f286288322899e535fc4cdb42d